### PR TITLE
Use the official repo rather than using a fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM golang
 
-RUN go get github.com/syoya/cloudsql-proxy/cmd/cloud_sql_proxy
+RUN go get github.com/GoogleCloudPlatform/cloudsql-proxy/cmd/cloud_sql_proxy
 
 EXPOSE 3306
 
 CMD echo $GCLOUD_ACCOUNT_JSON | base64 --decode > /gcloud-account.json && \
   cloud_sql_proxy \
     -dir=/cloudsql \
-    -instances=$INSTANCE_NAME=tcp:3306 \
+    -instances=$INSTANCE_NAME=tcp:0.0.0.0:3306 \
     -credential_file=/gcloud-account.json


### PR DESCRIPTION
Just a suggestion to use the official repo rather than requiring you to keep your fork up to date, since your repo's change can be done by just changing how flags are used.

BTW: I'm happy to pull in any changes you would like to make to the official repo to make docker integration easier. Feel free to send pull requests/file issues for any sort of functionality you need!

(Also, it'd be nice to add a note in the README that it's important to ensure that the firewall of the machine this container is running on should be locked down, otherwise it's possible to accidentally expose your Cloud SQL instance to the Internet!)
